### PR TITLE
chore(ci): add scripts to prepare test env. for podman-desktop E2E tests

### DIFF
--- a/scripts/windows/remote_machine.ps1
+++ b/scripts/windows/remote_machine.ps1
@@ -1,0 +1,49 @@
+# Prepare remote machine powershell script
+$podmanMachine="podman-machine"
+$remoteMachine="remote-machine"
+write-host "Preparing podman machine $podmanMachine"
+
+podman machine init --now $podmanMachine
+
+podman pull ghcr.io/podmandesktop-ci/alpine-remote
+
+$commandOut = $("podman image exists podmandesktop-ci/alpine-remote"; $?)
+if ( $commandOut -eq 'False') {
+    write-host "Image is not present on the machine"
+    exit 1
+} else {
+    write-host "alpine-remote is present on the machine"
+}
+
+# Prepare the remote-machine for remote connection
+
+# Get default system connection, load it from json
+$json = podman system connection ls --format json | ConvertFrom-Json
+foreach ($item in $json) { 
+    if ($item.Default -match "True" ) { 
+        $name=$($item.Name) 
+        $uri=$($item.URI)
+        $identity=$($item.Indentity)
+    }
+}
+
+write-host "Default connection - Name: $name, URI: $uri, Identity: $identity"
+
+# Clean up the access to the podman machine
+# Do not remove ~/.local/share/containers/podman as there are keys to the machine
+podman system connection rm $podmanMachine
+podman system connection rm $podmanMachine-root
+
+# remove default connections and other podman related files fron APPDATA\containers
+rm -r $env:APPDATA\containers\*
+
+# remove other configuration files from USERPROFILE\.config\containers
+rm -r $env:USERPROFILE\.config\containers
+
+# create a connection from previous information
+podman system connection add $remoteMachine --identity $identity $uri
+
+# check connection
+podman system connection --format json
+
+# run the remote e2e tests...

--- a/scripts/windows/remote_machine.sh
+++ b/scripts/windows/remote_machine.sh
@@ -1,0 +1,40 @@
+#!/bin/bash
+podmanMachine="podman-machine"
+remoteMachine="remote-machine"
+
+echo "Preparing remote podman machine..."
+
+podman machine init --now $podmanMachine
+
+podman pull ghcr.io/podmandesktop-ci/alpine-remote
+
+podman image exists podmandesktop-ci/alpine-remote && echo "Image exists... " || { echo "image does not exists"; exit 1 }
+
+# Parse the podman system connection json to get default connection
+
+name=$(podman system connection ls --format json | jq '.[] | select(.Default==true)' | jq -r '.Name')
+uri=$(podman system connection ls --format json | jq '.[] | select(.Default==true)' | jq -r '.URI')
+identity=$(podman system connection ls --format json | jq '.[] | select(.Default==true)' | jq -r '.Identity')
+
+echo "Default connection - Name: $name, URI: $uri, Identity: $identity"
+
+podman system connection rm $podmanMachine
+podman system connection rm $podmanMachine-root
+
+# remove default connections and other podman related file
+if [[ "$(uname)" = *Linux* ]]; then 
+    rm -rf /run/user/1000/podman/*podman-machine*
+fi
+
+# Do not remove ~/.local/share/containers/podman as there are keys to the machine
+
+# remove other configuration files from USERPROFILE\.config\containers
+rm -rf ~/.config/containers
+
+# create a connection from previous information
+podman system connection add $remoteMachine --identity $identity $uri
+
+# check connection
+podman system connection --format json
+
+# run the remote e2e tests...


### PR DESCRIPTION
Fixes #243.

First proposal for the scripts to run on particular platforms to prepare to run podman desktop e2e tests: testing podman-remote feature.