### PR TITLE
chore: update containers org to podman-desktop

### DIFF
--- a/.github/workflows/desktop-e2e-podman-windows-matrix.yaml
+++ b/.github/workflows/desktop-e2e-podman-windows-matrix.yaml
@@ -5,7 +5,7 @@ on:
   workflow_dispatch:
     inputs:
       fork:
-        default: 'containers'
+        default: 'podman-desktop'
         description: 'Podman Desktop repo fork'
         type: string
         required: true
@@ -81,7 +81,7 @@ jobs:
     steps:
     - name: Set the default env. variables
       env:
-        DEFAULT_FORK: 'containers'
+        DEFAULT_FORK: 'podman-desktop'
         DEFAULT_BRANCH: 'main'
         DEFAULT_NPM_TARGET: 'test:e2e'
         DEFAULT_PODMAN_PROVIDER: 'wsl'

--- a/.github/workflows/desktop-e2e-test-job-windows.yaml
+++ b/.github/workflows/desktop-e2e-test-job-windows.yaml
@@ -5,7 +5,7 @@ on:
   workflow_dispatch:
     inputs:
       pd_repo_options:
-        default: 'REPO=podman-desktop,FORK=containers,BRANCH=main'
+        default: 'REPO=podman-desktop,FORK=podman-desktop,BRANCH=main'
         description: 'Podman Desktop Extension repo, fork and branch'
         type: string
         required: true
@@ -76,7 +76,7 @@ jobs:
         DEFAULT_PODMAN_PROVIDER: 'wsl'
         DEFAULT_PODMAN_OPTIONS: 'INIT=1,START=1,ROOTFUL=1,NETWORKING=0'
         DEFAULT_EXT_REPO_OPTIONS: 'REPO=podman-desktop-redhat-account-ext,FORK=redhat-developer,BRANCH=main'
-        DEFAULT_PD_REPO_OPTIONS: 'REPO=podman-desktop,FORK=containers,BRANCH=main'
+        DEFAULT_PD_REPO_OPTIONS: 'REPO=podman-desktop,FORK=podman-desktop,BRANCH=main'
         DEFAULT_IMAGES_VERSIONS: 'BUILDER="v0.0.2",PODMAN="v0.0.2",RUNNER="v0.0.2"'
       run: |
         echo "NPM_TARGET=${{ github.event.inputs.npm_target || env.DEFAULT_NPM_TARGET }}" >> $GITHUB_ENV

--- a/.github/workflows/podman-desktop-e2e-kubernetes.yaml
+++ b/.github/workflows/podman-desktop-e2e-kubernetes.yaml
@@ -67,13 +67,13 @@ jobs:
     steps:
     - name: Get Podman version used by Desktop
       run: |
-        version=$(curl https://raw.githubusercontent.com/containers/podman-desktop/main/extensions/podman/packages/extension/src/podman5.json | jq -r '.version')
+        version=$(curl https://raw.githubusercontent.com/podman-desktop/podman-desktop/main/extensions/podman/packages/extension/src/podman5.json | jq -r '.version')
         echo "Default Podman Version from Podman Desktop: ${version}"
         echo "PD_PODMAN_VERSION=${version}" >> $GITHUB_ENV
 
     - name: Set the default env. variables
       env:
-        DEFAULT_FORK: 'containers'
+        DEFAULT_FORK: 'podman-desktop'
         DEFAULT_BRANCH: 'main'
         DEFAULT_NPM_TARGET: 'test:e2e:k8s'
         DEFAULT_ENV_VARS: 'TEST_PODMAN_MACHINE=false'

--- a/.github/workflows/podman-desktop-e2e-nightly-windows-hyperv.yaml
+++ b/.github/workflows/podman-desktop-e2e-nightly-windows-hyperv.yaml
@@ -6,7 +6,7 @@ on:
   workflow_dispatch:
     inputs:
       fork:
-        default: 'containers'
+        default: 'podman-desktop'
         description: 'Podman Desktop repo fork'
         type: string
         required: true
@@ -65,13 +65,13 @@ jobs:
     steps:
     - name: Get Podman version used by Desktop
       run: |
-        version=$(curl https://raw.githubusercontent.com/containers/podman-desktop/main/extensions/podman/packages/extension/src/podman5.json | jq -r '.version')
+        version=$(curl https://raw.githubusercontent.com/podman-desktop/podman-desktop/main/extensions/podman/packages/extension/src/podman5.json | jq -r '.version')
         echo "Default Podman Version from Podman Desktop: ${version}"
         echo "PD_PODMAN_VERSION=${version}" >> $GITHUB_ENV
 
     - name: Set the default env. variables
       env:
-        DEFAULT_FORK: 'containers'
+        DEFAULT_FORK: 'podman-desktop'
         DEFAULT_BRANCH: 'main'
         DEFAULT_NPM_TARGET: 'test:e2e'
         DEFAULT_PODMAN_PROVIDER: 'hyperv'

--- a/.github/workflows/podman-desktop-e2e-nightly-windows-wsl.yaml
+++ b/.github/workflows/podman-desktop-e2e-nightly-windows-wsl.yaml
@@ -6,7 +6,7 @@ on:
   workflow_dispatch:
     inputs:
       fork:
-        default: 'containers'
+        default: 'podman-desktop'
         description: 'Podman Desktop repo fork'
         type: string
         required: true
@@ -65,7 +65,7 @@ jobs:
     steps:
     - name: Set the default env. variables
       env:
-        DEFAULT_FORK: 'containers'
+        DEFAULT_FORK: 'podman-desktop'
         DEFAULT_BRANCH: 'main'
         DEFAULT_NPM_TARGET: 'test:e2e'
         DEFAULT_PODMAN_PROVIDER: 'wsl'

--- a/.github/workflows/podman-desktop-e2e-remote-windows.yaml
+++ b/.github/workflows/podman-desktop-e2e-remote-windows.yaml
@@ -7,7 +7,7 @@ on:
   workflow_dispatch:
     inputs:
       pd_repo_options:
-        default: 'REPO=podman-desktop,FORK=containers,BRANCH=main'
+        default: 'REPO=podman-desktop,FORK=podman-desktop,BRANCH=main'
         description: 'Podman Desktop Extension repo, fork and branch'
         type: string
         required: true
@@ -71,7 +71,7 @@ jobs:
         DEFAULT_NPM_TARGET: 'test:e2e:remote'
         DEFAULT_PODMAN_PROVIDER: 'wsl'
         DEFAULT_PODMAN_OPTIONS: 'INIT=0,START=0,ROOTFUL=0,NETWORKING=0'
-        DEFAULT_PD_REPO_OPTIONS: 'REPO=podman-desktop,FORK=containers,BRANCH=main'
+        DEFAULT_PD_REPO_OPTIONS: 'REPO=podman-desktop,FORK=podman-desktop,BRANCH=main'
         DEFAULT_HOST_FLAVOR: 'Standard_D8s_v4'
         DEFAULT_ENV_VARS: 'ELECTRON_ENABLE_INSPECT=true'
         DEFAULT_URL: 'https://api.cirrus-ci.com/v1/artifact/github/containers/podman/Artifacts/binary/podman-remote-release-windows_amd64.zip'

--- a/.github/workflows/podman-desktop-e2e-windows.yaml
+++ b/.github/workflows/podman-desktop-e2e-windows.yaml
@@ -7,7 +7,7 @@ on:
   workflow_dispatch:
     inputs:
       fork:
-        default: 'containers'
+        default: 'podman-desktop'
         description: 'Podman Desktop repo fork'
         type: string
         required: true
@@ -71,7 +71,7 @@ jobs:
     steps:
     - name: Set the default env. variables
       env:
-        DEFAULT_FORK: 'containers'
+        DEFAULT_FORK: 'podman-desktop'
         DEFAULT_BRANCH: 'main'
         DEFAULT_NPM_TARGET: 'test:e2e'
         DEFAULT_PODMAN_PROVIDER: 'wsl'

--- a/.github/workflows/podman-e2e-windows.yaml
+++ b/.github/workflows/podman-e2e-windows.yaml
@@ -74,7 +74,7 @@ jobs:
     - name: Run podman desktop e2e
       run: |
         # Get latest built 
-        tag=$(curl --silent https://api.github.com/repos/containers/podman-desktop/releases | jq -r 'map(select(.prerelease)) | first | .tag_name')
+        tag=$(curl --silent https://api.github.com/repos/podman-desktop/podman-desktop/releases | jq -r 'map(select(.prerelease)) | first | .tag_name')
         # Run e2e tests
         podman run --rm -d --name pd-e2e-windows \
           -e TARGET_HOST=$(cat host) \
@@ -89,7 +89,7 @@ jobs:
               pd-e2e/run.ps1 \
                   -wslInstallFix 'false' \
                   -targetFolder pd-e2e \
-                  -pdUrl "https://github.com/containers/podman-desktop/releases/download/${tag}/podman-desktop-${tag:1}.exe" \
+                  -pdUrl "https://github.com/podman-desktop/podman-desktop/releases/download/${tag}/podman-desktop-${tag:1}.exe" \
                   -junitResultsFilename podman-desktop-e2e-results-${tag}.xml \
                   -resultsFolder pd-e2e-results
         # Check logs 
@@ -99,7 +99,7 @@ jobs:
       timeout-minutes: 60
       run: |
         # Get latest built 
-        tag=$(curl --silent https://api.github.com/repos/containers/podman-desktop/releases | jq -r 'map(select(.prerelease)) | first | .tag_name')
+        tag=$(curl --silent https://api.github.com/repos/podman-desktop/podman-desktop/releases | jq -r 'map(select(.prerelease)) | first | .tag_name')
         # Run e2e tests
         podman run --rm -d --name podman-e2e \
           -e TARGET_HOST=$(cat host) \

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # podman-desktop-e2e
 
-This project define a set of e2e tests around [podman desktop](https://github.com/containers/podman-desktop), this is a complementary set of e2e tests for those user stories which requires interaction beyond the podman desktop app itself with some third party apps (i.e installers from extensions).
+This project define a set of e2e tests around [podman desktop](https://github.com/podman-desktop/podman-desktop), this is a complementary set of e2e tests for those user stories which requires interaction beyond the podman desktop app itself with some third party apps (i.e installers from extensions).
 
 ## Overview
 


### PR DESCRIPTION
PR update occurrences of `containers` org to `podman-desktop`, which is new org name.

Fixes #269 