### PR TITLE
chore: add debugging workflow for testing-prereleases

### DIFF
--- a/.github/workflows/prerelease-desktop-e2e-debug-job-windows.yaml
+++ b/.github/workflows/prerelease-desktop-e2e-debug-job-windows.yaml
@@ -1,0 +1,263 @@
+name: Debug Workflow for Testing-Prereleases Podman Desktop E2E
+run-name: Debugging Nightly Podman Desktop E2E Tests
+
+on:
+  workflow_dispatch:
+    inputs:
+      create_machine:
+        default: true
+        description: 'If to create new machine - default to true, or to use existing(requires manual setup)'
+        type: boolean
+        required: true
+      pd_repo_options:
+        default: 'REPO=podman-desktop,FORK=podman-desktop,BRANCH=main'
+        description: 'Podman Desktop Extension repo, fork and branch'
+        type: string
+        required: true
+      ext_repo_options:
+        default: 'REPO=podman-desktop-extension-ai-lab,FORK=containers,BRANCH=main,TESTS=0'
+        description: 'Podman Desktop Extension repo, fork, branch and if run ext. tests'
+        type: string
+        required: true
+      npm_target:
+        default: 'test:e2e'
+        description: 'npm target to run tests'
+        type: string
+        required: true
+      podman_remote_url:
+        default: 'https://github.com/containers/podman/releases/download/v5.3.1/podman-5.3.1-setup.exe'
+        description: 'podman latest version exe'
+        type: string
+        required: true
+      podman_desktop_url:
+        default: 'https://github.com/podman-desktop/testing-prereleases/releases/download/v1.16.0-202501090247-57bf7774e68/podman-desktop-1.16.0-202501090247-57bf7774e68-x64.exe'
+        description: 'podman desktop nightly exe url'
+        type: string
+        required: true
+      podman_options:
+        default: 'INIT=1,START=1,ROOTFUL=1,NETWORKING=0'
+        description: 'Podman machine configuration options, no spaces'
+        type: 'string'
+        required: true
+      podman_provider:
+        type: choice
+        description: 'Podman virtualization provider, default is wsl, alternative hyperv'
+        options:
+        - wsl
+        - hyperv
+        required: true
+      env_vars:
+        default: 'TEST_PODMAN_MACHINE=true'
+        description: 'Env. Variables passed into target machine, ie: VAR1=xxx,VAR2=true,VAR3=15,VAR4="Pass me along"'
+        type: 'string'
+        required: true
+      images_version:
+        default: 'BUILDER="v0.0.3",PODMAN="v0.0.3",RUNNER="v0.0.3"'
+        description: 'Testing images versions, no spaces'
+        type: 'string'
+        required: true
+jobs:
+  windows:
+    name: ${{ matrix.windows-version }} - Debug
+    timeout-minutes: 120
+    runs-on: ubuntu-latest
+    env:
+      MAPT_VERSION: v0.7.2
+      MAPT_IMAGE: quay.io/redhat-developer/mapt
+    strategy:
+      fail-fast: false
+      matrix:
+        windows-version: ['11']
+        windows-featurepack: ['24h2-ent']
+
+    steps:
+    - name: Set the default env. variables
+      env:
+        DEFAULT_CREATE_MACHINE: true
+        DEFAULT_NPM_TARGET: 'test:e2e'
+        DEFAULT_PODMAN_PROVIDER: 'wsl'
+        DEFAULT_PODMAN_OPTIONS: 'INIT=1,START=1,ROOTFUL=1,NETWORKING=0'
+        DEFAULT_EXT_REPO_OPTIONS: 'REPO=podman-desktop-extension-ai-lab,FORK=containers,BRANCH=main,TESTS=0'
+        DEFAULT_PD_REPO_OPTIONS: 'REPO=podman-desktop,FORK=podman-desktop,BRANCH=main'
+        DEFAULT_ENV_VARS: 'TEST_PODMAN_MACHINE=true'
+        DEFAULT_URL: 'https://api.cirrus-ci.com/v1/artifact/github/containers/podman/Artifacts/binary/podman-remote-release-windows_amd64.zip'
+        DEFAULT_PD_URL: 'https://github.com/podman-desktop/testing-prereleases/releases/download/v1.16.0-202501090247-57bf7774e68/podman-desktop-1.16.0-202501090247-57bf7774e68-x64.exe'
+        DEFAULT_IMAGES_VERSIONS: 'BUILDER="v0.0.3",PODMAN="v0.0.3",RUNNER="v0.0.3"'
+      run: |
+        echo "CREATE_MACHINE=${{ github.event.inputs.create_machine || env.DEFAULT_CREATE_MACHINE }}" >> $GITHUB_ENV  
+        echo "NPM_TARGET=${{ github.event.inputs.npm_target || env.DEFAULT_NPM_TARGET }}" >> $GITHUB_ENV
+        echo "PODMAN_PROVIDER=${{ github.event.inputs.podman_provider || env.DEFAULT_PODMAN_PROVIDER }}" >> $GITHUB_ENV
+        echo "PODMAN_URL=${{ github.event.inputs.podman_remote_url || env.DEFAULT_URL }}" >> $GITHUB_ENV
+        echo "PD_URL=${{ github.event.inputs.podman_desktop_url || env.DEFAULT_PD_URL }}" >> $GITHUB_ENV
+        echo "ENV_VARS=${{ github.event.inputs.env_vars || env.DEFAULT_ENV_VARS }}" >> $GITHUB_ENV
+        echo "${{ github.event.inputs.podman_options || env.DEFAULT_PODMAN_OPTIONS }}" | awk -F ',' \
+         '{for (i=1; i<=NF; i++) {split($i, kv, "="); print "PODMAN_"kv[1]"="kv[2]}}' >> $GITHUB_ENV
+        echo "${{ github.event.inputs.ext_repo_options || env.DEFAULT_EXT_REPO_OPTIONS }}" | awk -F ',' \
+         '{for (i=1; i<=NF; i++) {split($i, kv, "="); print "EXT_"kv[1]"="kv[2]}}' >> $GITHUB_ENV
+        echo "${{ github.event.inputs.pd_repo_options || env.DEFAULT_PD_REPO_OPTIONS }}" | awk -F ',' \
+        '{for (i=1; i<=NF; i++) {split($i, kv, "="); print "PD_"kv[1]"="kv[2]}}' >> $GITHUB_ENV
+        echo "${{ github.event.inputs.images_version || env.DEFAULT_IMAGES_VERSIONS }}" | awk -F ',' \
+         '{for (i=1; i<=NF; i++) {split($i, kv, "="); print "PDE2E_"kv[1]"="kv[2]}}' >> $GITHUB_ENV
+
+    - name: Create instance
+      if: ${{ env.CREATE_MACHINE }}
+      run: |
+        # Create instance
+        podman run -d --name windows-create --rm \
+          -v ${PWD}:/workspace:z \
+          -e ARM_TENANT_ID=${{ secrets.ARM_TENANT_ID }} \
+          -e ARM_SUBSCRIPTION_ID=${{ secrets.ARM_SUBSCRIPTION_ID }} \
+          -e ARM_CLIENT_ID=${{ secrets.ARM_CLIENT_ID }} \
+          -e ARM_CLIENT_SECRET='${{ secrets.ARM_CLIENT_SECRET }}' \
+          ${{ env.MAPT_IMAGE }}:${{ env.MAPT_VERSION }} azure \
+            windows create \
+            --project-name 'windows-desktop' \
+            --backed-url 'file:///workspace' \
+            --conn-details-output '/workspace' \
+            --windows-version '${{ matrix.windows-version }}' \
+            --windows-featurepack '${{ matrix.windows-featurepack }}' \
+            --nested-virt \
+            --cpus 8 \
+            --memory 16 \
+            --tags project=podman-desktop \
+            --spot
+        # Check logs 
+        podman logs -f windows-create
+
+    - name: Setup Connection to Existing instance
+      if: ${{ ! env.CREATE_MACHINE }}
+      run: |
+        # we need to create a content for host, id_rsa, username, userpassword files from repository tmp secrets.
+        # should be secrets.REMOTE_HOST, secrets.REMOTE_USER, secrets.REMOTE_RSA, secrets.REMOTE_PASS
+        cat << EOF > ./host
+            ${{ secrets.REMOTE_HOST }}
+        EOF
+        cat << EOF > ./username
+        cat ${{ secrets.REMOTE_USER }}
+        EOF
+        cat << EOF > ./id_rsa
+        cat ${{ secrets.REMOTE_RSA }}
+        EOF
+        chmod 600 ./id_rsa
+        cat << EOF > ./userpassword
+        cat ${{ secrets.REMOTE_PASS }}
+        EOF
+
+    - name: Check instance system info
+      run: |
+        ssh -i id_rsa \
+          -o StrictHostKeyChecking=no \
+          -o UserKnownHostsFile=/dev/null \
+          -o ServerAliveInterval=30 \
+          -o ServerAliveCountMax=1200 \
+          $(cat username)@$(cat host) "systeminfo"
+
+    - name: Emulate X session 
+      run: |
+        # use fake rdp to emulate an active x session
+        podman run -d --name x-session \
+          -e RDP_HOST=$(cat host) \
+          -e RDP_USER=$(cat username) \
+          -e RDP_PASSWORD=$(cat userpassword) \
+          quay.io/rhqp/frdp:v0.0.1
+        # Wait until the x session has been created
+        podman wait --condition running x-session
+        # Check logs for the x session
+        podman logs x-session
+
+    - name: Download Podman nightly, do not initialize
+      run: |
+        podman run --rm -d --name pde2e-podman-run \
+          -e TARGET_HOST=$(cat host) \
+          -e TARGET_HOST_USERNAME=$(cat username) \
+          -e TARGET_HOST_KEY_PATH=/data/id_rsa \
+          -e TARGET_FOLDER=pd-e2e \
+          -e TARGET_CLEANUP=false \
+          -e TARGET_RESULTS=results \
+          -e OUTPUT_FOLDER=/data \
+          -e DEBUG=true \
+          -v $PWD:/data:z \
+          quay.io/odockal/pde2e-podman:${{ env.PDE2E_PODMAN }}-windows \
+            pd-e2e/podman.ps1 \
+              -downloadUrl "${{ env.PODMAN_URL }}" \
+              -targetFolder pd-e2e \
+              -resultsFolder results \
+              -initialize 0 \
+              -rootful 0 \
+              -start 0 \
+              -installWSL 0
+        # check logs
+        podman logs -f pde2e-podman-run
+
+    - name: Run Podman Desktop Playwright E2E tests
+      env:
+        PODMANDESKTOP_CI_BOT_TOKEN: ${{ secrets.PODMANDESKTOP_CI_BOT_TOKEN }}
+      run: |
+        echo "PODMANDESKTOP_CI_BOT_TOKEN=${PODMANDESKTOP_CI_BOT_TOKEN}" > secrets.txt
+        podman run -d --name pde2e-runner-run \
+          -e TARGET_HOST=$(cat host) \
+          -e TARGET_HOST_USERNAME=$(cat username) \
+          -e TARGET_HOST_KEY_PATH=/data/id_rsa \
+          -e TARGET_FOLDER=pd-e2e \
+          -e TARGET_RESULTS=results \
+          -e OUTPUT_FOLDER=/data \
+          -e DEBUG=true \
+          -v $PWD:/data:z \
+          -v $PWD/secrets.txt:/opt/pde2e-runner/secrets.txt:z \
+          quay.io/odockal/pde2e-runner:${{ env.PDE2E_RUNNER }}-windows \
+              pd-e2e/runner.ps1 \
+                -targetFolder pd-e2e \
+                -resultsFolder results \
+                -podmanPath $(cat results/podman-location.log) \
+                -pdUrl ${{ env.PD_URL }} \
+                -fork ${{ env.PD_FORK }} \
+                -branch ${{ env.PD_BRANCH }} \
+                -extRepo ${{ env.EXT_REPO }} \
+                -extFork ${{ env.EXT_FORK }} \
+                -extBranch ${{ env.EXT_BRANCH }} \
+                -extTests ${{ env.EXT_TESTS }} \
+                -npmTarget ${{ env.NPM_TARGET }} \
+                -initialize ${{ env.PODMAN_INIT }} \
+                -rootful ${{ env.PODMAN_ROOTFUL }} \
+                -start ${{ env.PODMAN_START }} \
+                -userNetworking ${{ env.PODMAN_NETWORKING }} \
+                -podmanProvider ${{ env.PODMAN_PROVIDER }} \
+                -envVars ${{ env.ENV_VARS }} \
+                -secretFile secrets.txt
+        # check logs
+        podman logs -f pde2e-runner-run
+
+    - name: Destroy instance
+      if: ${{ env.CREATE_MACHINE }}
+      run: |
+        # Destroy instance
+        podman run -d --name windows-destroy --rm \
+          -v ${PWD}:/workspace:z \
+          -e ARM_TENANT_ID=${{ secrets.ARM_TENANT_ID }} \
+          -e ARM_SUBSCRIPTION_ID=${{ secrets.ARM_SUBSCRIPTION_ID }} \
+          -e ARM_CLIENT_ID=${{ secrets.ARM_CLIENT_ID }} \
+          -e ARM_CLIENT_SECRET='${{ secrets.ARM_CLIENT_SECRET }}' \
+          ${{ env.MAPT_IMAGE }}:${{ env.MAPT_VERSION }} azure \
+            windows destroy \
+            --project-name 'windows-desktop' \
+            --backed-url 'file:///workspace'
+        # Check logs
+        podman logs -f windows-destroy
+
+    - name: Publish Test Report
+      uses: mikepenz/action-junit-report@v5
+      if: always() # always run even if the previous step fails
+      with:
+        fail_on_failure: true
+        include_passed: true
+        detailed_summary: true
+        require_tests:  true
+        report_paths: '**/*results.xml'
+
+    - name: Upload test artifacts
+      uses: actions/upload-artifact@v4
+      if: always()
+      with:
+        name: results-e2e-${{ matrix.windows-version }}-debug
+        path: |
+          results/*


### PR DESCRIPTION
Fixes #277 and #291.

The workflow runs on demand only for now. 
Executor can choose to either provide specific secrets ahead of running the workflow, if he has access to the running machine (Secrets needs to be set to reuse existing machine: `REMOTE_HOST`, `REMOTE_USER`, `REMOTE_RSA`, `REMOTE_PASS`) or to run the workflow with creating a new machine.

Also, one needs to provide an URL to a Podman Desktop binary with enabled electron inspection.