### PR TITLE
test(e2e): workflow to run the stress test on windows

### DIFF
--- a/.github/workflows/podman-desktop-e2e-remote-stress-test-windows.yaml
+++ b/.github/workflows/podman-desktop-e2e-remote-stress-test-windows.yaml
@@ -1,0 +1,248 @@
+name: Podman Desktop Podman-Remote E2E Stress Test
+run-name: Podman Desktop Remote-Podman E2E Stress Test
+
+on:
+  schedule:
+    - cron: '0 5 * * 1' #run every monday at 5AM
+  workflow_dispatch:
+    inputs:
+      pd_repo_options:
+        default: 'REPO=podman-desktop,FORK=podman-desktop,BRANCH=main'
+        description: 'Podman Desktop Extension repo, fork and branch'
+        type: string
+        required: true
+      npm_target:
+        default: 'test:e2e:stress-test'
+        description: 'npm target to run tests'
+        type: string
+        required: true
+      podman_remote_url:
+        default: 'https://github.com/containers/podman/releases/download/v5.2.5/podman-5.2.5-setup.exe'
+        description: 'podman latest released version exe'
+        type: string
+        required: true
+      podman_options:
+        default: 'INIT=0,START=0,ROOTFUL=0,NETWORKING=0'
+        description: 'Podman machine configuration options, no spaces'
+        type: 'string'
+        required: true
+      podman_provider:
+        type: choice
+        description: 'Podman virtualization provider, default is wsl, alternative hyperv'
+        options:
+        - wsl
+        - hyperv
+        required: true
+      env_vars:
+        default: 'ELECTRON_ENABLE_INSPECT=true'
+        description: 'Env. Variables passed into target machine, ie: VAR1=xxx,VAR2=true,VAR3=15,VAR4="Pass me along"'
+        type: 'string'
+        required: true
+      images_version:
+        default: 'BUILDER="v0.0.3",PODMAN="v0.0.3",RUNNER="v0.0.3"'
+        description: 'Testing images versions, no spaces'
+        type: 'string'
+        required: true
+      host_flavor:
+        default: 'Standard_D8s_v4'
+        description: 'Azure agent flavor, ie: Standard_D4a_v4 or others'
+        type: 'string'
+        required: true
+jobs:
+  windows:
+    name: ${{ matrix.windows-version }} - ${{ matrix.windows-featurepack }}
+    timeout-minutes: 90
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      checks: write
+    env:
+      MAPT_VERSION: v0.7.4
+      MAPT_IMAGE: quay.io/redhat-developer/mapt
+    strategy:
+      fail-fast: false
+      matrix:
+        windows-version: ['11']
+        windows-featurepack: ['24h2-ent']
+
+    steps:
+    - name: Set the default env. variables
+      env:
+        DEFAULT_NPM_TARGET: 'test:e2e:stress-test'
+        DEFAULT_PODMAN_PROVIDER: 'wsl'
+        DEFAULT_PODMAN_OPTIONS: 'INIT=0,START=0,ROOTFUL=0,NETWORKING=0'
+        DEFAULT_PD_REPO_OPTIONS: 'REPO=podman-desktop,FORK=podman-desktop,BRANCH=main'
+        DEFAULT_HOST_FLAVOR: 'Standard_D8s_v4'
+        DEFAULT_ENV_VARS: 'ELECTRON_ENABLE_INSPECT=true'
+        DEFAULT_URL: 'https://api.cirrus-ci.com/v1/artifact/github/containers/podman/Artifacts/binary/podman-remote-release-windows_amd64.zip'
+        DEFAULT_IMAGES_VERSIONS: 'BUILDER="v0.0.2",PODMAN="v0.0.2",RUNNER="v0.0.3"'
+      run: |
+        echo "NPM_TARGET=${{ github.event.inputs.npm_target || env.DEFAULT_NPM_TARGET }}" >> $GITHUB_ENV
+        echo "PODMAN_PROVIDER=${{ github.event.inputs.podman_provider || env.DEFAULT_PODMAN_PROVIDER }}" >> $GITHUB_ENV
+        echo "PODMAN_URL=${{ github.event.inputs.podman_remote_url || env.DEFAULT_URL }}" >> $GITHUB_ENV
+        echo "ENV_VARS=${{ github.event.inputs.env_vars || env.DEFAULT_ENV_VARS }}" >> $GITHUB_ENV
+        echo "HOST_FLAVOR=${{ github.event.inputs.host_flavor || env.DEFAULT_HOST_FLAVOR }}" >> $GITHUB_ENV
+        echo "${{ github.event.inputs.podman_options || env.DEFAULT_PODMAN_OPTIONS }}" | awk -F ',' \
+         '{for (i=1; i<=NF; i++) {split($i, kv, "="); print "PODMAN_"kv[1]"="kv[2]}}' >> $GITHUB_ENV
+        echo "${{ github.event.inputs.pd_repo_options || env.DEFAULT_PD_REPO_OPTIONS }}" | awk -F ',' \
+        '{for (i=1; i<=NF; i++) {split($i, kv, "="); print "PD_"kv[1]"="kv[2]}}' >> $GITHUB_ENV
+        echo "${{ github.event.inputs.images_version || env.DEFAULT_IMAGES_VERSIONS }}" | awk -F ',' \
+         '{for (i=1; i<=NF; i++) {split($i, kv, "="); print "PDE2E_"kv[1]"="kv[2]}}' >> $GITHUB_ENV
+
+    - name: Create instance
+      run: |
+        # Create instance
+        podman run -d --name windows-create --rm \
+          -v ${PWD}:/workspace:z \
+          -e ARM_TENANT_ID=${{ secrets.ARM_TENANT_ID }} \
+          -e ARM_SUBSCRIPTION_ID=${{ secrets.ARM_SUBSCRIPTION_ID }} \
+          -e ARM_CLIENT_ID=${{ secrets.ARM_CLIENT_ID }} \
+          -e ARM_CLIENT_SECRET='${{ secrets.ARM_CLIENT_SECRET }}' \
+          ${{ env.MAPT_IMAGE }}:${{ env.MAPT_VERSION }} azure \
+            windows create \
+            --project-name 'windows-desktop' \
+            --backed-url 'file:///workspace' \
+            --conn-details-output '/workspace' \
+            --windows-version '${{ matrix.windows-version }}' \
+            --windows-featurepack '${{ matrix.windows-featurepack }}' \
+            --vmsize '${{ env.HOST_FLAVOR }}' \
+            --tags project=podman-desktop \
+            --spot
+        # Check logs 
+        podman logs -f windows-create
+
+    - name: Check instance system info
+      run: |
+        ssh -i id_rsa \
+          -o StrictHostKeyChecking=no \
+          -o UserKnownHostsFile=/dev/null \
+          -o ServerAliveInterval=30 \
+          -o ServerAliveCountMax=1200 \
+          $(cat username)@$(cat host) "systeminfo"
+
+    - name: Emulate X session 
+      run: |
+        # use fake rdp to emulate an active x session
+        podman run -d --name x-session \
+          -e RDP_HOST=$(cat host) \
+          -e RDP_USER=$(cat username) \
+          -e RDP_PASSWORD=$(cat userpassword) \
+          quay.io/rhqp/frdp:v0.0.1
+        # Wait until the x session has been created
+        podman wait --condition running x-session
+        # Check logs for the x session
+        podman logs x-session
+
+    - name: Setup dependencies and build Podman Desktop locally
+      run: |
+        podman run -d --name pde2e-builder-run \
+          -e TARGET_HOST=$(cat host) \
+          -e TARGET_HOST_USERNAME=$(cat username) \
+          -e TARGET_HOST_KEY_PATH=/data/id_rsa \
+          -e TARGET_FOLDER=pd-e2e \
+          -e TARGET_CLEANUP=false \
+          -e TARGET_RESULTS=results \
+          -e OUTPUT_FOLDER=/data \
+          -e DEBUG=true \
+          -v $PWD:/data:z \
+          quay.io/odockal/pde2e-builder:${{ env.PDE2E_BUILDER }}-windows \
+              pd-e2e/builder.ps1 \
+                -targetFolder pd-e2e \
+                -resultsFolder results \
+                -fork ${{ env.PD_FORK }} \
+                -branch ${{ env.PD_BRANCH }} \
+                -envVars ${{ env.ENV_VARS }}
+        # check logs
+        podman logs -f pde2e-builder-run
+
+    - name: Download Podman nightly, do not initialize
+      run: |
+        podman run --rm -d --name pde2e-podman-run \
+          -e TARGET_HOST=$(cat host) \
+          -e TARGET_HOST_USERNAME=$(cat username) \
+          -e TARGET_HOST_KEY_PATH=/data/id_rsa \
+          -e TARGET_FOLDER=pd-e2e \
+          -e TARGET_CLEANUP=false \
+          -e TARGET_RESULTS=results \
+          -e OUTPUT_FOLDER=/data \
+          -e DEBUG=true \
+          -v $PWD:/data:z \
+          quay.io/odockal/pde2e-podman:${{ env.PDE2E_PODMAN }}-windows \
+            pd-e2e/podman.ps1 \
+              -downloadUrl ${{ env.PODMAN_URL }} \
+              -targetFolder pd-e2e \
+              -resultsFolder results \
+              -initialize 0 \
+              -rootful 0 \
+              -start 0 \
+              -installWSL 0
+        # check logs
+        podman logs -f pde2e-podman-run
+
+    - name: Run Podman Desktop Playwright E2E tests
+      env:
+        PODMANDESKTOP_CI_BOT_TOKEN: ${{ secrets.PODMANDESKTOP_CI_BOT_TOKEN }}
+      run: |
+        echo "PODMANDESKTOP_CI_BOT_TOKEN=${PODMANDESKTOP_CI_BOT_TOKEN}" > secrets.txt
+        podman run -d --name pde2e-runner-run \
+          -e TARGET_HOST=$(cat host) \
+          -e TARGET_HOST_USERNAME=$(cat username) \
+          -e TARGET_HOST_KEY_PATH=/data/id_rsa \
+          -e TARGET_FOLDER=pd-e2e \
+          -e TARGET_RESULTS=results \
+          -e OUTPUT_FOLDER=/data \
+          -e DEBUG=true \
+          -v $PWD:/data:z \
+          -v $PWD/secrets.txt:/opt/pde2e-runner/secrets.txt:z \
+          quay.io/odockal/pde2e-runner:${{ env.PDE2E_RUNNER }}-windows \
+              pd-e2e/runner.ps1 \
+                -targetFolder pd-e2e \
+                -resultsFolder results \
+                -podmanPath $(cat results/podman-location.log) \
+                -fork ${{ env.PD_FORK }} \
+                -branch ${{ env.PD_BRANCH }} \
+                -npmTarget ${{ env.NPM_TARGET }} \
+                -initialize ${{ env.PODMAN_INIT }} \
+                -rootful ${{ env.PODMAN_ROOTFUL }} \
+                -start ${{ env.PODMAN_START }} \
+                -userNetworking ${{ env.PODMAN_NETWORKING }} \
+                -podmanProvider ${{ env.PODMAN_PROVIDER }} \
+                -envVars ${{ env.ENV_VARS }} \
+                -scriptPaths 'stress_test_remote.ps1'
+        # check logs
+        podman logs -f pde2e-runner-run
+
+    - name: Destroy instance
+      if: always()
+      run: |
+        # Destroy instance
+        podman run -d --name windows-destroy --rm \
+          -v ${PWD}:/workspace:z \
+          -e ARM_TENANT_ID=${{ secrets.ARM_TENANT_ID }} \
+          -e ARM_SUBSCRIPTION_ID=${{ secrets.ARM_SUBSCRIPTION_ID }} \
+          -e ARM_CLIENT_ID=${{ secrets.ARM_CLIENT_ID }} \
+          -e ARM_CLIENT_SECRET='${{ secrets.ARM_CLIENT_SECRET }}' \
+          ${{ env.MAPT_IMAGE }}:${{ env.MAPT_VERSION }} azure \
+            windows destroy \
+            --project-name 'windows-desktop' \
+            --backed-url 'file:///workspace'
+        # Check logs
+        podman logs -f windows-destroy
+
+    - name: Publish Test Report
+      uses: mikepenz/action-junit-report@v4
+      if: always() # always run even if the previous step fails
+      with:
+        fail_on_failure: true
+        include_passed: true
+        detailed_summary: true
+        require_tests:  true
+        report_paths: '**/*results.xml'
+
+    - name: Upload test artifacts
+      uses: actions/upload-artifact@v4
+      if: always()
+      with:
+        name: results-e2e-${{ matrix.windows-version }}-debug
+        path: |
+          results/*

--- a/.github/workflows/podman-desktop-e2e-stress-ui-windows.yaml
+++ b/.github/workflows/podman-desktop-e2e-stress-ui-windows.yaml
@@ -65,7 +65,7 @@ jobs:
     steps:
     - name: Set the default env. variables
       env:
-        DEFAULT_NPM_TARGET: 'test:e2e:stress-test'
+        DEFAULT_NPM_TARGET: 'test:e2e:ui-stress'
         DEFAULT_PODMAN_PROVIDER: 'wsl'
         DEFAULT_PODMAN_OPTIONS: 'INIT=1,START=1,ROOTFUL=0,NETWORKING=0'
         DEFAULT_PD_REPO_OPTIONS: 'REPO=podman-desktop,FORK=podman-desktop,BRANCH=main'

--- a/.github/workflows/podman-desktop-e2e-stress-ui-windows.yaml
+++ b/.github/workflows/podman-desktop-e2e-stress-ui-windows.yaml
@@ -1,5 +1,5 @@
-name: Podman Desktop Podman-Remote E2E Stress Test
-run-name: Podman Desktop Remote-Podman E2E Stress Test
+name: Podman Desktop E2E UI Stress Test
+run-name: Podman Desktop E2E UI Stress Test
 
 on:
   schedule:
@@ -12,17 +12,17 @@ on:
         type: string
         required: true
       npm_target:
-        default: 'test:e2e:stress-test'
+        default: 'test:e2e:ui-stress'
         description: 'npm target to run tests'
         type: string
         required: true
       podman_remote_url:
-        default: 'https://github.com/containers/podman/releases/download/v5.2.5/podman-5.2.5-setup.exe'
+        default: 'https://github.com/containers/podman/releases/download/v5.3.2/podman-5.3.2-setup.exe'
         description: 'podman latest released version exe'
         type: string
         required: true
       podman_options:
-        default: 'INIT=0,START=0,ROOTFUL=0,NETWORKING=0'
+        default: 'INIT=1,START=1,ROOTFUL=0,NETWORKING=0'
         description: 'Podman machine configuration options, no spaces'
         type: 'string'
         required: true
@@ -43,9 +43,9 @@ on:
         description: 'Testing images versions, no spaces'
         type: 'string'
         required: true
-      host_flavor:
-        default: 'Standard_D8s_v4'
-        description: 'Azure agent flavor, ie: Standard_D4a_v4 or others'
+      host_params: 
+        default: 'CPUS="8",MEMORY="16"'
+        description: Number of CPUs and GBs of memory, no spaces
         type: 'string'
         required: true
 jobs:
@@ -53,9 +53,6 @@ jobs:
     name: ${{ matrix.windows-version }} - ${{ matrix.windows-featurepack }}
     timeout-minutes: 90
     runs-on: ubuntu-latest
-    permissions:
-      contents: read
-      checks: write
     env:
       MAPT_VERSION: v0.7.4
       MAPT_IMAGE: quay.io/redhat-developer/mapt
@@ -70,9 +67,9 @@ jobs:
       env:
         DEFAULT_NPM_TARGET: 'test:e2e:stress-test'
         DEFAULT_PODMAN_PROVIDER: 'wsl'
-        DEFAULT_PODMAN_OPTIONS: 'INIT=0,START=0,ROOTFUL=0,NETWORKING=0'
+        DEFAULT_PODMAN_OPTIONS: 'INIT=1,START=1,ROOTFUL=0,NETWORKING=0'
         DEFAULT_PD_REPO_OPTIONS: 'REPO=podman-desktop,FORK=podman-desktop,BRANCH=main'
-        DEFAULT_HOST_FLAVOR: 'Standard_D8s_v4'
+        DEFAULT_HOST_PARAMS: 'CPUS="8",MEMORY="16"'
         DEFAULT_ENV_VARS: 'ELECTRON_ENABLE_INSPECT=true'
         DEFAULT_URL: 'https://api.cirrus-ci.com/v1/artifact/github/containers/podman/Artifacts/binary/podman-remote-release-windows_amd64.zip'
         DEFAULT_IMAGES_VERSIONS: 'BUILDER="v0.0.2",PODMAN="v0.0.2",RUNNER="v0.0.3"'
@@ -81,7 +78,8 @@ jobs:
         echo "PODMAN_PROVIDER=${{ github.event.inputs.podman_provider || env.DEFAULT_PODMAN_PROVIDER }}" >> $GITHUB_ENV
         echo "PODMAN_URL=${{ github.event.inputs.podman_remote_url || env.DEFAULT_URL }}" >> $GITHUB_ENV
         echo "ENV_VARS=${{ github.event.inputs.env_vars || env.DEFAULT_ENV_VARS }}" >> $GITHUB_ENV
-        echo "HOST_FLAVOR=${{ github.event.inputs.host_flavor || env.DEFAULT_HOST_FLAVOR }}" >> $GITHUB_ENV
+        echo "${{ github.event.inputs.host_params || env.DEFAULT_HOST_PARAMS }}" >> | awk -F ',' \
+        '{for (i=1; i<=NF; i++) {split($i, kv, "="); print "HOST_PARAMS_"kv[1]"="kv[2]}}' >> $GITHUB_ENV
         echo "${{ github.event.inputs.podman_options || env.DEFAULT_PODMAN_OPTIONS }}" | awk -F ',' \
          '{for (i=1; i<=NF; i++) {split($i, kv, "="); print "PODMAN_"kv[1]"="kv[2]}}' >> $GITHUB_ENV
         echo "${{ github.event.inputs.pd_repo_options || env.DEFAULT_PD_REPO_OPTIONS }}" | awk -F ',' \
@@ -105,7 +103,9 @@ jobs:
             --conn-details-output '/workspace' \
             --windows-version '${{ matrix.windows-version }}' \
             --windows-featurepack '${{ matrix.windows-featurepack }}' \
-            --vmsize '${{ env.HOST_FLAVOR }}' \
+            --nested-virt \
+            --cpus '${{ env.HOST_PARAMS_CPUS }}' \
+            --memory '${{ env.HOST_PARAMS_MEMORY }}' \
             --tags project=podman-desktop \
             --spot
         # Check logs 
@@ -208,7 +208,7 @@ jobs:
                 -userNetworking ${{ env.PODMAN_NETWORKING }} \
                 -podmanProvider ${{ env.PODMAN_PROVIDER }} \
                 -envVars ${{ env.ENV_VARS }} \
-                -scriptPaths 'stress_test_remote.ps1'
+                -scriptPaths 'stress_test_ui.ps1'
         # check logs
         podman logs -f pde2e-runner-run
 
@@ -236,6 +236,7 @@ jobs:
         fail_on_failure: true
         include_passed: true
         detailed_summary: true
+        annotate_only: true
         require_tests:  true
         report_paths: '**/*results.xml'
 


### PR DESCRIPTION
Adds a new workflow to run the stress test on windows, as required by [#4836](https://github.com/podman-desktop/podman-desktop/issues/4836)

Related PRs:
[test(e2e): stress test UI with lots of objects - test case #10900](https://github.com/podman-desktop/podman-desktop/pull/10900)
[test(e2e): script to setup podman on windows machine #10](https://github.com/odockal/pde2e-runner/pull/10)