### PR TITLE
fix(ci): Update CRIU download URL

### DIFF
--- a/.github/workflows/podman-desktop-e2e-stress-ui-linux.yaml
+++ b/.github/workflows/podman-desktop-e2e-stress-ui-linux.yaml
@@ -107,7 +107,7 @@ jobs:
         echo "install necessary dependencies for criu package which is not part of ${ubuntu_version}"
         sudo apt-get install -qq libprotobuf32t64 python3-protobuf libnet1
         echo "install criu manually from static location"
-        curl -sLO http://cz.archive.ubuntu.com/ubuntu/pool/universe/c/criu/criu_3.16.1-2_amd64.deb && sudo dpkg -i criu_3.16.1-2_amd64.deb
+        curl -sLO http://archive.ubuntu.com/ubuntu/pool/universe/c/criu/criu_3.16.1-2_amd64.deb && sudo dpkg -i criu_3.16.1-2_amd64.deb
 
         echo "installing/update podman package..."
         sudo apt-get -qq -y install podman || { echo "Start fallback steps for podman nightly installation from a static mirror" && \


### PR DESCRIPTION
### What does this PR do?

The `cz.archive.ubuntu.com` mirror for CRIU is currently unavailable, causing CI failures. This commit updates the download URL to use `archive.ubuntu.com` directly, which is a more reliable and generally available mirror.

This change ensures that the Podman update process in CI environments can reliably download and install the `criu` package, preventing build failures related to unreachable repositories.

### Screenshot / video of UI

<!-- If this PR is changing UI, please include
screenshots or screencasts showing the difference -->

### What issues does this PR fix or reference?

<!-- Include any related issues from Podman Desktop
repository (or from another issue tracker). -->

### How to test this PR?

<!-- Please explain steps to reproduce -->
