### PR TITLE
chore(test): updating job timeout

### DIFF
--- a/.github/workflows/desktop-e2e-podman-windows-matrix.yaml
+++ b/.github/workflows/desktop-e2e-podman-windows-matrix.yaml
@@ -55,7 +55,7 @@ on:
 jobs:
   windows:
     name: ${{ matrix.windows-version }} - ${{ matrix.rootful == '0' && 'rootless' || 'rootful' }} ${{ matrix.user-networking == '1' && '- user mode networking enabled' || '' }}
-    timeout-minutes: 120
+    timeout-minutes: 180
     runs-on: ubuntu-latest
     env:
       MAPT_VERSION: v0.7.4

--- a/.github/workflows/desktop-e2e-test-job-windows.yaml
+++ b/.github/workflows/desktop-e2e-test-job-windows.yaml
@@ -60,7 +60,7 @@ on:
 jobs:
   windows:
     name: ${{ matrix.windows-version }} - Debug
-    timeout-minutes: 120
+    timeout-minutes: 180
     runs-on: ubuntu-latest
     strategy:
       fail-fast: false

--- a/.github/workflows/podman-desktop-e2e-kubernetes.yaml
+++ b/.github/workflows/podman-desktop-e2e-kubernetes.yaml
@@ -45,7 +45,7 @@ on:
 
 jobs:
   windows:
-    timeout-minutes: 120
+    timeout-minutes: 180
     runs-on: ubuntu-latest
     permissions:
       contents: read

--- a/.github/workflows/podman-desktop-e2e-nightly-windows-hyperv.yaml
+++ b/.github/workflows/podman-desktop-e2e-nightly-windows-hyperv.yaml
@@ -43,7 +43,7 @@ on:
 
 jobs:
   windows:
-    timeout-minutes: 120
+    timeout-minutes: 180
     runs-on: ubuntu-latest
     permissions:
       contents: read

--- a/.github/workflows/podman-desktop-e2e-nightly-windows-wsl.yaml
+++ b/.github/workflows/podman-desktop-e2e-nightly-windows-wsl.yaml
@@ -43,7 +43,7 @@ on:
 
 jobs:
   windows:
-    timeout-minutes: 120
+    timeout-minutes: 180
     runs-on: ubuntu-latest
     permissions:
       contents: read

--- a/.github/workflows/podman-desktop-e2e-windows.yaml
+++ b/.github/workflows/podman-desktop-e2e-windows.yaml
@@ -47,7 +47,7 @@ on:
 
 jobs:
   windows:
-    timeout-minutes: 120
+    timeout-minutes: 180
     runs-on: ubuntu-latest
     permissions:
       contents: read

--- a/.github/workflows/podman-e2e-windows.yaml
+++ b/.github/workflows/podman-e2e-windows.yaml
@@ -7,7 +7,7 @@ on:
 
 jobs:
   windows:
-    timeout-minutes: 120
+    timeout-minutes: 180
     runs-on: ubuntu-latest
     env:
       MAPT_VERSION: ${{ vars.MAPT_VERSION_TAG }}

--- a/.github/workflows/prerelease-desktop-e2e-debug-job-windows.yaml
+++ b/.github/workflows/prerelease-desktop-e2e-debug-job-windows.yaml
@@ -60,7 +60,7 @@ on:
 jobs:
   windows:
     name: ${{ matrix.windows-version }} - Debug
-    timeout-minutes: 120
+    timeout-minutes: 180
     runs-on: ubuntu-latest
     env:
       MAPT_VERSION: ${{ vars.MAPT_VERSION_TAG }}


### PR DESCRIPTION
updates nightly jobs timeouts from 2 to 3 hours.