### PR TITLE
chore(ci): use development podman version by default on TF ci

### DIFF
--- a/.github/workflows/podman-desktop-e2e-testing-farm.yaml
+++ b/.github/workflows/podman-desktop-e2e-testing-farm.yaml
@@ -32,11 +32,12 @@ on:
         description: 'Podman Desktop repo branch'
         type: string
         required: true
-      podman_version: 
-        default: 'latest'
-        description: 'Specify the desired Podman version (e.g., "5.5.2"). For release candidates, use a format that includes "rc" (e.g., "5.6.0~rc1")'
+      podman_version:
+        default: 'nightly'
+        description: 'Podman version to install (e.g., "5.5.2", "5.6.0~rc1"). Use "latest" for stable or "nightly" for the latest development build.'
         type: string
         required: true
+
 
 jobs:
   pd-e2e-testing-farm-ci: 
@@ -48,7 +49,7 @@ jobs:
         env:
           DEFAULT_FORK: 'podman-desktop'
           DEFAULT_BRANCH: 'main'
-          DEFAULT_PODMAN_VERSION: 'latest'
+          DEFAULT_PODMAN_VERSION: 'nightly'
         run: |
           echo "FORK=${{ github.event.inputs.fork || env.DEFAULT_FORK }}" >> $GITHUB_ENV
           echo "BRANCH=${{ github.event.inputs.branch || env.DEFAULT_BRANCH }}" >> $GITHUB_ENV

--- a/plans/scripts/install-podman.sh
+++ b/plans/scripts/install-podman.sh
@@ -5,12 +5,20 @@ set -eu
 sudo dnf remove -y podman
 
 # Construct the download URL for the specific Podman version.
-COMPOSE_VERSION="fc$(echo "$COMPOSE" | cut -d '-' -f 2)"
+COMPOSE_VERSION="fc$(echo "$COMPOSE" | cut -d'-' -f2)"
 CUSTOM_PODMAN_URL="https://kojipkgs.fedoraproject.org//packages/podman/${PODMAN_VERSION}/1.${COMPOSE_VERSION}/${ARCH}/podman-${PODMAN_VERSION}-1.${COMPOSE_VERSION}.${ARCH}.rpm"
 
-# If the latest stable Podman version is requested, install it from the official Fedora repository.
-# Otherwise, download and install the specific RPM package.
-if [[ "$PODMAN_VERSION" == "latest" ]]; then
+# Install Podman based on the requested version:
+#   - "nightly": latest nightly build from rhcontainerbot/podman-next COPR repository
+#   - "latest": latest stable release from official Fedora repositories
+#   - other: install the exact RPM from Fedora Koji
+if [[ "$PODMAN_VERSION" == "nightly" ]]; then
+    sudo dnf copr enable -y rhcontainerbot/podman-next
+    sudo dnf install -y podman --disablerepo=testing-farm-tag-repository 
+    PODMAN_VERSION="$(dnf --quiet \
+        --repofrompath=podman-next,https://download.copr.fedorainfracloud.org/results/rhcontainerbot/podman-next/fedora-$(rpm -E %fedora)/${ARCH}/ \
+        list --showduplicates podman 2>/dev/null | grep dev | tail -n1 | cut -d':' -f2 | cut -d'-' -f1 )"
+elif [[ "$PODMAN_VERSION" == "latest" ]]; then
     sudo dnf install -y podman --disablerepo=testing-farm-tag-repository
     PODMAN_VERSION="$(curl -s https://api.github.com/repos/containers/podman/releases/latest | jq -r .tag_name | sed 's/^v//')"
 else
@@ -20,7 +28,7 @@ else
 fi
 
 # Verify that the installed Podman version matches the expected version. 
-INSTALLED_PODMAN_VERSION="$(podman --version | cut -d ' ' -f 3)"
+INSTALLED_PODMAN_VERSION="$(podman --version | cut -d' ' -f3)"
 NORMALIZED_PODMAN_VERSION="${PODMAN_VERSION//\~/-}"
 
 if [[ "$INSTALLED_PODMAN_VERSION" != "$NORMALIZED_PODMAN_VERSION" ]]; then


### PR DESCRIPTION
tested on the fork: https://github.com/amisskii/podman-desktop-e2e/actions/runs/16947251639