### PR TITLE
Always upload playwright junit file in Testing Farm workflow

### DIFF
--- a/.github/workflows/podman-desktop-e2e-testing-farm.yaml
+++ b/.github/workflows/podman-desktop-e2e-testing-farm.yaml
@@ -94,7 +94,7 @@ jobs:
         if: always()
         run: |
           TF_PLAYWRIGHT_JUNIT_URL="${{ env.TF_ARTIFACTS_URL }}/${{ env.TF_WORK_ID }}/plans/pd-e2e-plan/${{ env.NPM_TARGET }}/execute/data/guest/default-0/tmt/${{ env.NPM_TARGET }}-test-1/data/junit-results.xml"
-          curl -o playwright-junit-results.xml "$TF_PLAYWRIGHT_JUNIT_URL"
+          curl -o junit-playwright-results.xml "$TF_PLAYWRIGHT_JUNIT_URL"
 
       - name: Publish test report to PR
         if: always()
@@ -105,7 +105,7 @@ jobs:
           detailed_summary: true
           annotate_only: true
           require_tests: true
-          report_paths: '**/playwright-junit-results.xml'
+          report_paths: '**/junit-playwright-results.xml'
 
       - name: Download test artifacts from Testing Farm
         if: failure()
@@ -137,8 +137,10 @@ jobs:
             "$TF_VIDEOS_URL"
 
       - name: Upload test artifacts
-        if: failure()
+        if: always()
         uses: actions/upload-artifact@v4
         with:
           name: testing-farm-artifacts-${{ matrix.fedora-version }}
-          path: results/*
+          path: |
+            results/*
+            **/junit-playwright-results.xml


### PR DESCRIPTION
Since test results are now being uploaded to Report Portal, it’s necessary to always generate and upload a junit file to the artifacts, even when all tests pass.